### PR TITLE
Guard against cyclic references in arrays

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2015, Yeoman team
+Copyright (c) 2016, Test Double, LLC; 2015, Yeoman team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/contributing.md
+++ b/contributing.md
@@ -1,1 +1,0 @@
-See the [contributing docs](https://github.com/yeoman/yeoman/blob/master/contributing.md)

--- a/index.js
+++ b/index.js
@@ -68,7 +68,7 @@ module.exports = function (val, opts, pad) {
 
 			var ret = '[' + tokens.newLine + val.map(function (el, i) {
 				var eol = val.length - 1 === i ? tokens.newLine : ',' + tokens.newLineOrSpace;
-				return tokens.indent + stringify(el, opts, tokens.indent) + eol;
+				return tokens.indent + stringify(el, opts, pad + opts.indent) + eol;
 			}).join('') + tokens.pad + ']';
 
 			seen.pop(val);
@@ -92,7 +92,7 @@ module.exports = function (val, opts, pad) {
 
 				var eol = objKeys.length - 1 === i ? tokens.newLine : ',' + tokens.newLineOrSpace;
 				var key = /^[a-z$_][a-z$_0-9]*$/i.test(el) ? el : stringify(el, opts);
-				return tokens.indent + key + ': ' + stringify(val[el], opts, tokens.indent) + eol;
+				return tokens.indent + key + ': ' + stringify(val[el], opts, pad + opts.indent) + eol;
 			}).join('') + tokens.pad + '}';
 
 			seen.pop(val);

--- a/index.js
+++ b/index.js
@@ -9,6 +9,38 @@ module.exports = function (val, opts, pad) {
 		opts = opts || {};
 		opts.indent = opts.indent || '\t';
 		pad = pad || '';
+		var tokens;
+		if(opts.inlineCharacterLimit == void 0) {
+			tokens = {
+				newLine: '\n',
+				newLineOrSpace: '\n',
+				pad: pad,
+				indent: pad + opts.indent
+			};
+		} else {
+			tokens = {
+				newLine: '@@__STRINGIFY_OBJECT_NEW_LINE__@@',
+				newLineOrSpace: '@@__STRINGIFY_OBJECT_NEW_LINE_OR_SPACE__@@',
+				pad: '@@__STRINGIFY_OBJECT_PAD__@@',
+				indent: '@@__STRINGIFY_OBJECT_INDENT__@@'
+			}
+		}
+		var expandWhiteSpace = function(string) {
+			if (opts.inlineCharacterLimit == void 0) { return string; }
+			var oneLined = string.
+				replace(new RegExp(tokens.newLine, 'g'), '').
+				replace(new RegExp(tokens.newLineOrSpace, 'g'), ' ').
+				replace(new RegExp(tokens.pad + '|' + tokens.indent, 'g'), '');
+
+			if(oneLined.length <= opts.inlineCharacterLimit) {
+				return oneLined;
+			} else {
+				return string.
+					replace(new RegExp(tokens.newLine + '|' + tokens.newLineOrSpace, 'g'), '\n').
+					replace(new RegExp(tokens.pad, 'g'), pad).
+					replace(new RegExp(tokens.indent, 'g'), pad + opts.indent);
+			}
+		};
 
 		if (seen.indexOf(val) !== -1) {
 			return '"[Circular]"';
@@ -34,14 +66,14 @@ module.exports = function (val, opts, pad) {
 
 			seen.push(val);
 
-			var ret = '[\n' + val.map(function (el, i) {
-				var eol = val.length - 1 === i ? '\n' : ',\n';
-				return pad + opts.indent + stringify(el, opts, pad + opts.indent) + eol;
-			}).join('') + pad + ']';
+			var ret = '[' + tokens.newLine + val.map(function (el, i) {
+				var eol = val.length - 1 === i ? tokens.newLine : ',' + tokens.newLineOrSpace;
+				return tokens.indent + stringify(el, opts, tokens.indent) + eol;
+			}).join('') + tokens.pad + ']';
 
 			seen.pop(val);
 
-			return ret;
+			return expandWhiteSpace(ret);
 		}
 
 		if (isPlainObj(val)) {
@@ -53,19 +85,19 @@ module.exports = function (val, opts, pad) {
 
 			seen.push(val);
 
-			var ret = '{\n' + objKeys.map(function (el, i) {
+			var ret = '{' + tokens.newLine + objKeys.map(function (el, i) {
 				if (opts.filter && !opts.filter(val, el)) {
 					return '';
 				}
 
-				var eol = objKeys.length - 1 === i ? '\n' : ',\n';
+				var eol = objKeys.length - 1 === i ? tokens.newLine : ',' + tokens.newLineOrSpace;
 				var key = /^[a-z$_][a-z$_0-9]*$/i.test(el) ? el : stringify(el, opts);
-				return pad + opts.indent + key + ': ' + stringify(val[el], opts, pad + opts.indent) + eol;
-			}).join('') + pad + '}';
+				return tokens.indent + key + ': ' + stringify(val[el], opts, tokens.indent) + eol;
+			}).join('') + tokens.pad + '}';
 
 			seen.pop(val);
 
-			return ret;
+			return expandWhiteSpace(ret);
 		}
 
 		val = String(val).replace(/[\r\n]/g, function (x) {

--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ module.exports = function (val, opts, pad) {
 		opts.indent = opts.indent || '\t';
 		pad = pad || '';
 
+		if (seen.indexOf(val) !== -1) {
+			return '"[Circular]"';
+		}
+
 		if (val === null ||
 			val === undefined ||
 			typeof val === 'number' ||
@@ -28,17 +32,19 @@ module.exports = function (val, opts, pad) {
 				return '[]';
 			}
 
-			return '[\n' + val.map(function (el, i) {
+			seen.push(val);
+
+			var ret = '[\n' + val.map(function (el, i) {
 				var eol = val.length - 1 === i ? '\n' : ',\n';
 				return pad + opts.indent + stringify(el, opts, pad + opts.indent) + eol;
 			}).join('') + pad + ']';
+
+			seen.pop(val);
+
+			return ret;
 		}
 
 		if (isPlainObj(val)) {
-			if (seen.indexOf(val) !== -1) {
-				return '"[Circular]"';
-			}
-
 			var objKeys = Object.keys(val);
 
 			if (objKeys.length === 0) {

--- a/package.json
+++ b/package.json
@@ -1,14 +1,19 @@
 {
-  "name": "stringify-object",
-  "version": "2.3.1",
-  "description": "Stringify an object/array like JSON.stringify just without all the double-quotes",
+  "name": "stringify-object-with-one-liners",
+  "version": "1.0.0",
+  "description": "stringify-object + an option to inline short objects & arrays",
   "license": "BSD-2-Clause",
-  "repository": "yeoman/stringify-object",
+  "repository": "searls/stringify-object-with-one-liners",
   "author": {
+    "name": "Justin Searls",
+    "email": "searls@gmail.com",
+    "url": "testdouble.com"
+  },
+  "contributors": [{
     "name": "Sindre Sorhus",
     "email": "sindresorhus@gmail.com",
     "url": "sindresorhus.com"
-  },
+  }],
   "engines": {
     "node": ">=0.10.0"
   },

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,8 @@
 # stringify-object-with-one-liners [![Build Status](https://secure.travis-ci.org/searls/stringify-object-with-one-liners.svg?branch=master)](http://travis-ci.org/searls/stringify-object-with-one-liners)
 
+**Note: This is a fork of [stringify-object](https://github.com/yeoman/stringify-object) which adds the
+[inlineCharacterLimit](#inlinecharacterlimit) configuration option.**
+
 > Stringify an object/array like JSON.stringify just without all the double-quotes.
 
 Useful for when you want to get the string representation of an object in a formatted way.

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# stringify-object [![Build Status](https://secure.travis-ci.org/yeoman/stringify-object.svg?branch=master)](http://travis-ci.org/yeoman/stringify-object)
+# stringify-object-with-one-liners [![Build Status](https://secure.travis-ci.org/searls/stringify-object-with-one-liners.svg?branch=master)](http://travis-ci.org/searls/stringify-object-with-one-liners)
 
 > Stringify an object/array like JSON.stringify just without all the double-quotes.
 
@@ -10,7 +10,7 @@ It also handles circular references and lets you specify quote type.
 ## Install
 
 ```
-$ npm install --save stringify-object
+$ npm install --save stringify-object-with-one-liners
 ```
 
 
@@ -118,4 +118,4 @@ than 12 characters.
 
 ## License
 
-[BSD license](http://opensource.org/licenses/bsd-license.php) © Yeoman Team
+[BSD license](http://opensource.org/licenses/bsd-license.php) © Test Double LLC, Yeoman Team

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,43 @@ Type: `function`
 
 Expected to return a boolean of whether to keep the object.
 
+##### inlineCharacterLimit
+
+Type: `number`
+Default: undefined
+
+When set, will inline values up to `inlineCharacterLimit` length for the sake
+of more terse output.
+
+For example, given the example at the top of the README:
+
+```js
+var obj = {
+	foo: 'bar',
+	'arr': [1, 2, 3],
+	nested: { hello: "world" }
+};
+
+var pretty = stringifyObject(obj, {
+	indent: '  ',
+	singleQuotes: false,
+	inlineCharacterLimit: 12
+});
+
+console.log(pretty);
+/*
+{
+	foo: "bar",
+	arr: [1, 2, 3],
+	nested: {
+		hello: "world"
+	}
+}
+*/
+```
+
+As you can see, `arr` was printed as a one-liner because its string was shorter
+than 12 characters.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -104,3 +104,19 @@ it('should stringify complex circular arrays', function () {
 	array[0][0][0] = array;
 	assert.equal(stringifyObject(array), '[\n\t[\n\t\t[\n\t\t\t"[Circular]",\n\t\t\t10\n\t\t],\n\t\t"[Circular]"\n\t]\n]');
 });
+
+it('allows short objects to be one-lined', function () {
+	var object = { id: 8, name: 'Jane' }
+
+	assert.equal(stringifyObject(object), "{\n\tid: 8,\n\tname: 'Jane'\n}")
+	assert.equal(stringifyObject(object, { inlineCharacterLimit: 21}), "{id: 8, name: 'Jane'}")
+	assert.equal(stringifyObject(object, { inlineCharacterLimit: 20}), "{\n\tid: 8,\n\tname: 'Jane'\n}")
+});
+
+it('allows short arrays to be one-lined', function () {
+	var array = ['foo', { id: 8, name: 'Jane' }, 42]
+
+	assert.equal(stringifyObject(array), "[\n\t'foo',\n\t{\n\t\tid: 8,\n\t\tname: 'Jane'\n\t},\n\t42\n]")
+	assert.equal(stringifyObject(array, { inlineCharacterLimit: 34}), "['foo', {id: 8, name: 'Jane'}, 42]")
+	assert.equal(stringifyObject(array, { inlineCharacterLimit: 33}), "[\n\t'foo',\n\t{id: 8, name: 'Jane'},\n\t42\n]")
+});

--- a/test.js
+++ b/test.js
@@ -69,23 +69,23 @@ it('considering filter option to stringify an object', function () {
 	assert.equal(actual, '{\n\tbar: {\n\t\tval: 10\n\t}\n}');
 });
 
-it.skip('should not crash with circular references in arrays', function () {
+it('should not crash with circular references in arrays', function () {
 	var array = [];
 	array.push(array);
 	assert.doesNotThrow(
 		function () {
 			stringifyObject(array);
-		}, RangeError);
+		});
 
 	var nestedArray = [[]];
 	nestedArray[0][0] = nestedArray;
 	assert.doesNotThrow(
 		function () {
 			stringifyObject(nestedArray);
-		}, RangeError);
+		});
 });
 
-it.skip('should handle circular references in arrays', function () {
+it('should handle circular references in arrays', function () {
 	var array2 = [];
 	var array = [array2];
 	array2[0] = array2;
@@ -93,10 +93,10 @@ it.skip('should handle circular references in arrays', function () {
 	assert.doesNotThrow(
 		function () {
 			stringifyObject(array);
-		}, RangeError);
+		});
 });
 
-it.skip('should stringify complex circular arrays', function () {
+it('should stringify complex circular arrays', function () {
 	var array = [[[]]];
 	array[0].push(array);
 	array[0][0].push(array);

--- a/test.js
+++ b/test.js
@@ -120,3 +120,13 @@ it('allows short arrays to be one-lined', function () {
 	assert.equal(stringifyObject(array, { inlineCharacterLimit: 34}), "['foo', {id: 8, name: 'Jane'}, 42]")
 	assert.equal(stringifyObject(array, { inlineCharacterLimit: 33}), "[\n\t'foo',\n\t{id: 8, name: 'Jane'},\n\t42\n]")
 });
+
+it('does not mess up indents for complex objects', function(){
+	var object = {
+		arr: [1, 2, 3],
+		nested: { hello: "world" }
+	};
+
+	assert.equal(stringifyObject(object), "{\n\tarr: [\n\t\t1,\n\t\t2,\n\t\t3\n\t],\n\tnested: {\n\t\thello: 'world'\n\t}\n}");
+	assert.equal(stringifyObject(object, {inlineCharacterLimit: 12}), "{\n\tarr: [1, 2, 3],\n\tnested: {\n\t\thello: 'world'\n\t}\n}");
+});


### PR DESCRIPTION
This patch treats arrays just like objects, by adding arrays to the
`seen` array and popping them after iteration. It also pulls up the 
short-circuit to `return "[Circular]"` earlier in the listing, to 
emphatically break out of cyclic recursion as early as possible.

Also loosened the `doesNotThrow` assertions to guard against any error 
(for instance, max call stack exceeded) as well

I did my best to retain the existing code's style/formatting, mea culpa 
if I got anything wrong.

Fixes #24 cc/ #28