### PR TITLE
Implements a configurable "one-liner" option

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,38 @@ module.exports = function (val, opts, pad) {
 		opts = opts || {};
 		opts.indent = opts.indent || '\t';
 		pad = pad || '';
+		var tokens;
+		if(opts.inlineCharacterLimit == void 0) {
+			tokens = {
+				newLine: '\n',
+				newLineOrSpace: '\n',
+				pad: pad,
+				indent: pad + opts.indent
+			};
+		} else {
+			tokens = {
+				newLine: '@@__STRINGIFY_OBJECT_NEW_LINE__@@',
+				newLineOrSpace: '@@__STRINGIFY_OBJECT_NEW_LINE_OR_SPACE__@@',
+				pad: '@@__STRINGIFY_OBJECT_PAD__@@',
+				indent: '@@__STRINGIFY_OBJECT_INDENT__@@'
+			}
+		}
+		var expandWhiteSpace = function(string) {
+			if (opts.inlineCharacterLimit == void 0) { return string; }
+			var oneLined = string.
+				replace(new RegExp(tokens.newLine, 'g'), '').
+				replace(new RegExp(tokens.newLineOrSpace, 'g'), ' ').
+				replace(new RegExp(tokens.pad + '|' + tokens.indent, 'g'), '');
+
+			if(oneLined.length <= opts.inlineCharacterLimit) {
+				return oneLined;
+			} else {
+				return string.
+					replace(new RegExp(tokens.newLine + '|' + tokens.newLineOrSpace, 'g'), '\n').
+					replace(new RegExp(tokens.pad, 'g'), pad).
+					replace(new RegExp(tokens.indent, 'g'), pad + opts.indent);
+			}
+		};
 
 		if (seen.indexOf(val) !== -1) {
 			return '"[Circular]"';
@@ -34,14 +66,14 @@ module.exports = function (val, opts, pad) {
 
 			seen.push(val);
 
-			var ret = '[\n' + val.map(function (el, i) {
-				var eol = val.length - 1 === i ? '\n' : ',\n';
-				return pad + opts.indent + stringify(el, opts, pad + opts.indent) + eol;
-			}).join('') + pad + ']';
+			var ret = '[' + tokens.newLine + val.map(function (el, i) {
+				var eol = val.length - 1 === i ? tokens.newLine : ',' + tokens.newLineOrSpace;
+				return tokens.indent + stringify(el, opts, pad + opts.indent) + eol;
+			}).join('') + tokens.pad + ']';
 
 			seen.pop(val);
 
-			return ret;
+			return expandWhiteSpace(ret);
 		}
 
 		if (isPlainObj(val)) {
@@ -53,19 +85,19 @@ module.exports = function (val, opts, pad) {
 
 			seen.push(val);
 
-			var ret = '{\n' + objKeys.map(function (el, i) {
+			var ret = '{' + tokens.newLine + objKeys.map(function (el, i) {
 				if (opts.filter && !opts.filter(val, el)) {
 					return '';
 				}
 
-				var eol = objKeys.length - 1 === i ? '\n' : ',\n';
+				var eol = objKeys.length - 1 === i ? tokens.newLine : ',' + tokens.newLineOrSpace;
 				var key = /^[a-z$_][a-z$_0-9]*$/i.test(el) ? el : stringify(el, opts);
-				return pad + opts.indent + key + ': ' + stringify(val[el], opts, pad + opts.indent) + eol;
-			}).join('') + pad + '}';
+				return tokens.indent + key + ': ' + stringify(val[el], opts, pad + opts.indent) + eol;
+			}).join('') + tokens.pad + '}';
 
 			seen.pop(val);
 
-			return ret;
+			return expandWhiteSpace(ret);
 		}
 
 		val = String(val).replace(/[\r\n]/g, function (x) {

--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,43 @@ Type: `function`
 
 Expected to return a boolean of whether to keep the object.
 
+##### inlineCharacterLimit
+
+Type: `number`
+Default: undefined
+
+When set, will inline values up to `inlineCharacterLimit` length for the sake
+of more terse output.
+
+For example, given the example at the top of the README:
+
+```js
+var obj = {
+	foo: 'bar',
+	'arr': [1, 2, 3],
+	nested: { hello: "world" }
+};
+
+var pretty = stringifyObject(obj, {
+	indent: '  ',
+	singleQuotes: false,
+	inlineCharacterLimit: 12
+});
+
+console.log(pretty);
+/*
+{
+	foo: "bar",
+	arr: [1, 2, 3],
+	nested: {
+		hello: "world"
+	}
+}
+*/
+```
+
+As you can see, `arr` was printed as a one-liner because its string was shorter
+than 12 characters.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -104,3 +104,29 @@ it('should stringify complex circular arrays', function () {
 	array[0][0][0] = array;
 	assert.equal(stringifyObject(array), '[\n\t[\n\t\t[\n\t\t\t"[Circular]",\n\t\t\t10\n\t\t],\n\t\t"[Circular]"\n\t]\n]');
 });
+
+it('allows short objects to be one-lined', function () {
+	var object = { id: 8, name: 'Jane' }
+
+	assert.equal(stringifyObject(object), "{\n\tid: 8,\n\tname: 'Jane'\n}")
+	assert.equal(stringifyObject(object, { inlineCharacterLimit: 21}), "{id: 8, name: 'Jane'}")
+	assert.equal(stringifyObject(object, { inlineCharacterLimit: 20}), "{\n\tid: 8,\n\tname: 'Jane'\n}")
+});
+
+it('allows short arrays to be one-lined', function () {
+	var array = ['foo', { id: 8, name: 'Jane' }, 42]
+
+	assert.equal(stringifyObject(array), "[\n\t'foo',\n\t{\n\t\tid: 8,\n\t\tname: 'Jane'\n\t},\n\t42\n]")
+	assert.equal(stringifyObject(array, { inlineCharacterLimit: 34}), "['foo', {id: 8, name: 'Jane'}, 42]")
+	assert.equal(stringifyObject(array, { inlineCharacterLimit: 33}), "[\n\t'foo',\n\t{id: 8, name: 'Jane'},\n\t42\n]")
+});
+
+it('does not mess up indents for complex objects', function(){
+	var object = {
+		arr: [1, 2, 3],
+		nested: { hello: "world" }
+	};
+
+	assert.equal(stringifyObject(object), "{\n\tarr: [\n\t\t1,\n\t\t2,\n\t\t3\n\t],\n\tnested: {\n\t\thello: 'world'\n\t}\n}");
+	assert.equal(stringifyObject(object, {inlineCharacterLimit: 12}), "{\n\tarr: [1, 2, 3],\n\tnested: {\n\t\thello: 'world'\n\t}\n}");
+});


### PR DESCRIPTION
*(FYI: Submitting this separately from #30, since that hasn't been accepted yet and there is a merge conflict; to see the handled conflict check out how I [resolved the conflict](https://github.com/searls/stringify-object-with-one-liners/tree/47dcade8fafbe8adec95d4af005b561fb49cd6aa))*

This PR significantly increases the complexity of the module, and I would only recommend merging it if you believe it has general value. I'll plan on publishing my changes as a separate module.

For some cases, the added newlines & indents of short objects and arrays
makes the output unwieldy. This commit adds a new option
`inlineCharacterLimit`, which when set to a positive Number will
return stringified object or array that, with padding/indents/newlines
stripped would have a length less than `inlineCharacterLimit`.

As background, if I use stringify-object to print this argument list:

`foo(obj1, obj2)`

And `obj1` is `{a: 1, b: 2}` and `obj2` is `[1,2,3]`, and I try to
print a description of the invocation back to the user like this:

`'foo(' + stringifyObject(obj1) + ', ' + stringifyObject(obj2) + ')'`

Then what could be nice and terse as:

`'foo({a: 1, b: 2}, [1,2,3])'`

But will instead print something containing a lot of new lines, making
it hard to see the invocation being described.

I'm running into this a lot developing
https://github.com/testdouble/testdouble.js to have better output,
because using terse object and array params to pass to test doubles is
tremendously common, and I want to give users as best output as I can.