### PR TITLE
Guards against cyclic values in arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,10 @@ module.exports = function (val, opts, pad) {
 		opts.indent = opts.indent || '\t';
 		pad = pad || '';
 
+		if (seen.indexOf(val) !== -1) {
+			return '"[Circular]"';
+		}
+
 		if (val === null ||
 			val === undefined ||
 			typeof val === 'number' ||
@@ -28,17 +32,19 @@ module.exports = function (val, opts, pad) {
 				return '[]';
 			}
 
-			return '[\n' + val.map(function (el, i) {
+			seen.push(val);
+
+			var ret = '[\n' + val.map(function (el, i) {
 				var eol = val.length - 1 === i ? '\n' : ',\n';
 				return pad + opts.indent + stringify(el, opts, pad + opts.indent) + eol;
 			}).join('') + pad + ']';
+
+			seen.pop(val);
+
+			return ret;
 		}
 
 		if (isPlainObj(val)) {
-			if (seen.indexOf(val) !== -1) {
-				return '"[Circular]"';
-			}
-
 			var objKeys = Object.keys(val);
 
 			if (objKeys.length === 0) {

--- a/test.js
+++ b/test.js
@@ -69,23 +69,23 @@ it('considering filter option to stringify an object', function () {
 	assert.equal(actual, '{\n\tbar: {\n\t\tval: 10\n\t}\n}');
 });
 
-it.skip('should not crash with circular references in arrays', function () {
+it('should not crash with circular references in arrays', function () {
 	var array = [];
 	array.push(array);
 	assert.doesNotThrow(
 		function () {
 			stringifyObject(array);
-		}, RangeError);
+		});
 
 	var nestedArray = [[]];
 	nestedArray[0][0] = nestedArray;
 	assert.doesNotThrow(
 		function () {
 			stringifyObject(nestedArray);
-		}, RangeError);
+		});
 });
 
-it.skip('should handle circular references in arrays', function () {
+it('should handle circular references in arrays', function () {
 	var array2 = [];
 	var array = [array2];
 	array2[0] = array2;
@@ -93,10 +93,10 @@ it.skip('should handle circular references in arrays', function () {
 	assert.doesNotThrow(
 		function () {
 			stringifyObject(array);
-		}, RangeError);
+		});
 });
 
-it.skip('should stringify complex circular arrays', function () {
+it('should stringify complex circular arrays', function () {
 	var array = [[[]]];
 	array[0].push(array);
 	array[0][0].push(array);


### PR DESCRIPTION
This patch treats arrays just like objects, by adding arrays to the
seen array and popping them after iteration. It also pulls up the 
short-circuit to return "[Circular]" earlier in the listing, to 
emphatically break out of cyclic recursion as early as possible.

Also loosened the doesNotThrow assertions to guard against any error 
(for instance, max call stack exceeded) as well

I did my best to retain the existing code's style/formatting, mea culpa 
if I got anything wrong.

Fixes #24 cc/ #28