### PR TITLE
Add a transform option

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,11 @@ module.exports = (val, opts, pad) => {
 				const isSymbol = typeof el === 'symbol';
 				const isClassic = !isSymbol && /^[a-z$_][a-z$_0-9]*$/i.test(el);
 				const key = isSymbol || isClassic ? el : stringify(el, opts);
-				return tokens.indent + String(key) + ': ' + stringify(val[el], opts, pad + opts.indent) + eol;
+				let value = stringify(val[el], opts, pad + opts.indent);
+				if (opts.transform) {
+					value = opts.transform(val, el, value);
+				}
+				return tokens.indent + String(key) + ': ' + value + eol;
 			}).join('') + tokens.pad + '}';
 
 			seen.pop(val);

--- a/index.js
+++ b/index.js
@@ -76,7 +76,11 @@ module.exports = (val, opts, pad) => {
 
 			const ret = '[' + tokens.newLine + val.map((el, i) => {
 				const eol = val.length - 1 === i ? tokens.newLine : ',' + tokens.newLineOrSpace;
-				return tokens.indent + stringify(el, opts, pad + opts.indent) + eol;
+				let value = stringify(el, opts, pad + opts.indent);
+				if (opts.transform) {
+					value = opts.transform(val, i, value);
+				}
+				return tokens.indent + value + eol;
 			}).join('') + tokens.pad + ']';
 
 			seen.pop(val);

--- a/readme.md
+++ b/readme.md
@@ -95,9 +95,9 @@ const obj = {
 }
 
 const pretty = stringifyObject(obj, {
-	transform: function (obj, prop, originalResult) {
+	transform: (obj, prop, originalResult) => {
 		if (prop === 'password') {
-			return originalResult.replace(/\w/g,'*');
+			return originalResult.replace(/\w/g, '*');
 		} else {
 			return originalResult;
 		}

--- a/readme.md
+++ b/readme.md
@@ -79,6 +79,17 @@ Type: `Function`
 
 Expected to return a `boolean` of whether to include the property `prop` of the object `obj` in the output.
 
+##### transform(obj, prop, originalResult)
+
+Type: `Function`
+Default: `undefined`
+
+Expected to return a `String` that transforms the string that resulted from
+stringifying `obj[prop]`. This can be used to detect special types of objects
+that need to be stringified in a particular way. The `transform` function might
+return an alternate string in this case, otherwise returning the
+`originalResult`.
+
 ##### inlineCharacterLimit
 
 Type: `number`

--- a/readme.md
+++ b/readme.md
@@ -81,14 +81,38 @@ Expected to return a `boolean` of whether to include the property `prop` of the 
 
 ##### transform(obj, prop, originalResult)
 
-Type: `Function`
+Type: `Function`<br>
 Default: `undefined`
 
-Expected to return a `String` that transforms the string that resulted from
-stringifying `obj[prop]`. This can be used to detect special types of objects
-that need to be stringified in a particular way. The `transform` function might
-return an alternate string in this case, otherwise returning the
-`originalResult`.
+Expected to return a `string` that transforms the string that resulted from stringifying `obj[prop]`. This can be used to detect special types of objects that need to be stringified in a particular way. The `transform` function might return an alternate string in this case, otherwise returning the `originalResult`.
+
+Here's an example that uses the `transform` option to mask fields named "password":
+
+```js
+const obj = {
+	user: 'becky',
+	password: 'secret'
+}
+
+const pretty = stringifyObject(obj, {
+	transform: function (obj, prop, originalResult) {
+		if (prop === 'password') {
+			return originalResult.replace(/\w/g,'*');
+		} else {
+			return originalResult;
+		}
+	}
+});
+
+console.log(pretty);
+/*
+{
+	user: 'becky',
+	password: '******'
+}
+*/
+```
+
 
 ##### inlineCharacterLimit
 

--- a/test.js
+++ b/test.js
@@ -73,7 +73,14 @@ it('considering filter option to stringify an object', () => {
 });
 
 it('allows an object to be transformed', () => {
-	const obj = {foo: {val: 10}, bar: 9, baz: [8]};
+	const obj = {
+		foo: {
+			val: 10
+		},
+		bar: 9,
+		baz: [8]
+	};
+
 	const actual = stringifyObject(obj, {
 		transform: (obj, prop, result) => {
 			if (prop === 'val') {
@@ -86,6 +93,7 @@ it('allows an object to be transformed', () => {
 			return result;
 		}
 	});
+
 	assert.equal(actual, '{\n\tfoo: {\n\t\tval: 11\n\t},\n\tbar: \'9L\',\n\tbaz: [\n\t\tLOL\n\t]\n}');
 });
 

--- a/test.js
+++ b/test.js
@@ -72,6 +72,21 @@ it('considering filter option to stringify an object', () => {
 	assert.equal(actual, '{\n\tbar: {\n\t\tval: 10\n\t}\n}');
 });
 
+it('allows an object to be transformed', () => {
+	const obj = {foo: {val: 10}, bar: 9};
+	const actual = stringifyObject(obj, {
+		transform: (obj, prop, result) => {
+			if (prop === 'val') {
+				return String(obj[prop] + 1);
+			} else if (prop === 'bar') {
+				return '\'' + result + 'L\'';
+			}
+			return result;
+		}
+	});
+	assert.equal(actual, '{\n\tfoo: {\n\t\tval: 11\n\t},\n\tbar: \'9L\'\n}');
+});
+
 it('should not crash with circular references in arrays', () => {
 	const array = [];
 	array.push(array);

--- a/test.js
+++ b/test.js
@@ -73,18 +73,20 @@ it('considering filter option to stringify an object', () => {
 });
 
 it('allows an object to be transformed', () => {
-	const obj = {foo: {val: 10}, bar: 9};
+	const obj = {foo: {val: 10}, bar: 9, baz: [8]};
 	const actual = stringifyObject(obj, {
 		transform: (obj, prop, result) => {
 			if (prop === 'val') {
 				return String(obj[prop] + 1);
 			} else if (prop === 'bar') {
 				return '\'' + result + 'L\'';
+			} else if (obj[prop] === 8) {
+				return 'LOL';
 			}
 			return result;
 		}
 	});
-	assert.equal(actual, '{\n\tfoo: {\n\t\tval: 11\n\t},\n\tbar: \'9L\'\n}');
+	assert.equal(actual, '{\n\tfoo: {\n\t\tval: 11\n\t},\n\tbar: \'9L\',\n\tbaz: [\n\t\tLOL\n\t]\n}');
 });
 
 it('should not crash with circular references in arrays', () => {


### PR DESCRIPTION
Sometimes I want to stringify an object that might contain nested 
properties that need to be stringified specially. A `transform` 
function can be used to determine these special cases and return an
alternative string representation.