### PR TITLE
fix: update get-own-enumerable-property-symbols to fix es6 code issue

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 const isRegexp = require('is-regexp');
 const isObj = require('is-obj');
-const getOwnEnumPropSymbols = require('get-own-enumerable-property-symbols');
+const getOwnEnumPropSymbols = require('get-own-enumerable-property-symbols').default;
 
 module.exports = (val, opts, pad) => {
 	const seen = [];

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"json"
 	],
 	"dependencies": {
-		"get-own-enumerable-property-symbols": "^1.0.1",
+		"get-own-enumerable-property-symbols": "^2.0.1",
 		"is-obj": "^1.0.1",
 		"is-regexp": "^1.0.0"
 	},


### PR DESCRIPTION
First of all: Thanks for all the work you're doing! :)

We're using [react-element-to-jsx-string](https://github.com/algolia/react-element-to-jsx-string) which has `stringify-object` as dependency.

Unfortunately,  `react-element-to-jsx-string` only exported es6 code (arrow function) which causes it not to work without being run through babel in older browsers, such as IE11. They have since fixed it and ship an es5 version of their code. 

All tests still pass. :)