### PR TITLE
fix tests, bump get-own-enumerable-property-symbols version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
 		"json"
 	],
 	"dependencies": {
-		"get-own-enumerable-property-symbols": "^2.0.1",
+		"get-own-enumerable-property-symbols": "^3.0.0",
 		"is-obj": "^1.0.1",
 		"is-regexp": "^1.0.0"
 	},

--- a/test/index.js
+++ b/test/index.js
@@ -94,9 +94,11 @@ test('allows an object to be transformed', t => {
 		transform: (obj, prop, result) => {
 			if (prop === 'val') {
 				return String(obj[prop] + 1);
-			} else if (prop === 'bar') {
+			}
+			if (prop === 'bar') {
 				return '\'' + result + 'L\'';
-			} else if (obj[prop] === 8) {
+			}
+			if (obj[prop] === 8) {
 				return 'LOL';
 			}
 			return result;


### PR DESCRIPTION
This PR fixes tests and bumps get-own-enumerable-property-symbols version to 3.0.0 after this https://github.com/mightyiam/get-own-enumerable-property-symbols/pull/9