### PR TITLE
Fix improper string escaping

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,13 +125,14 @@ export default function stringifyObject(input, options, pad) {
 		}
 
 		input = String(input).replace(/[\r\n]/g, x => x === '\n' ? '\\n' : '\\r');
+		input = input.replace(/\\/g, '\\\\');
 
 		if (options.singleQuotes === false) {
 			input = input.replace(/"/g, '\\"');
 			return `"${input}"`;
 		}
 
-		input = input.replace(/\\?'/g, '\\\'');
+		input = input.replace(/'/g, '\\\'');
 		return `'${input}'`;
 	})(input, options, pad);
 }

--- a/index.js
+++ b/index.js
@@ -124,8 +124,8 @@ export default function stringifyObject(input, options, pad) {
 			return expandWhiteSpace(returnValue);
 		}
 
-		input = String(input).replace(/[\r\n]/g, x => x === '\n' ? '\\n' : '\\r');
 		input = input.replace(/\\/g, '\\\\');
+		input = String(input).replace(/[\r\n]/g, x => x === '\n' ? '\\n' : '\\r');
 
 		if (options.singleQuotes === false) {
 			input = input.replace(/"/g, '\\"');

--- a/test/index.js
+++ b/test/index.js
@@ -49,8 +49,23 @@ test('stringify an object', t => {
 	t.is(actual + '\n', fs.readFileSync(path.resolve(__dirname, 'fixtures/object.js'), 'utf8'));
 	t.is(
 		stringifyObject({foo: 'a \' b \' c \\\' d'}, {singleQuotes: true}),
-		'{\n\tfoo: \'a \\\' b \\\' c \\\' d\'\n}',
+		'{\n\tfoo: \'a \\\' b \\\' c \\\\\\\' d\'\n}',
 	);
+});
+
+test('string escaping works properly', t => {
+	t.is(stringifyObject('\\', {singleQuotes: true}), '\'\\\\\''); // \
+	t.is(stringifyObject('\\\'', {singleQuotes: true}), '\'\\\\\\\'\''); // \'
+	t.is(stringifyObject('\\"', {singleQuotes: true}), '\'\\\\"\''); // \"
+	t.is(stringifyObject('\\', {singleQuotes: false}), '"\\\\"'); // \
+	t.is(stringifyObject('\\\'', {singleQuotes: false}), '"\\\\\'"'); // \'
+	t.is(stringifyObject('\\"', {singleQuotes: false}), '"\\\\\\""'); // \"
+	/* eslint-disable no-eval */
+	t.is(eval(stringifyObject('\\\'')), '\\\'');
+	t.is(eval(stringifyObject('\\\'', {singleQuotes: false})), '\\\'');
+	/* eslint-enable */
+	// Regression test for #40
+	t.is(stringifyObject("a'a"), '\'a\\\'a\''); // eslint-disable-line quotes
 });
 
 test('detect reused object values as circular reference', t => {


### PR DESCRIPTION
Before, input strings like `'\\'` or `"\\"` were improperly escaped. For double quotes, backslashes were not escaped at all and for single quotes, they were basically ignored (due to `/\\?'/`).

The above examples now produce `'\\'`/`"\\"` instead of `'\'`/`"\"` and are thus valid strings again.