### PR TITLE
Correct indentation in readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -33,15 +33,15 @@ const pretty = stringifyObject(object, {
 console.log(pretty);
 /*
 {
-	foo: "bar",
-	arr: [
-		1,
-		2,
-		3
-	],
-	nested: {
-		hello: "world"
-	}
+  foo: "bar",
+  arr: [
+    1,
+    2,
+    3
+  ],
+  nested: {
+    hello: "world"
+  }
 }
 */
 ```
@@ -146,11 +146,11 @@ const pretty = stringifyObject(object, {
 console.log(pretty);
 /*
 {
-	foo: "bar",
-	arr: [1, 2, 3],
-	nested: {
-		hello: "world"
-	}
+  foo: "bar",
+  arr: [1, 2, 3],
+  nested: {
+    hello: "world"
+  }
 }
 */
 ```


### PR DESCRIPTION
you're passing two spaces `'  '` as the `indent` but the result in the readme file is using tabs.