### PR TITLE
Stringify most methods and function properties correctly

### DIFF
--- a/index.js
+++ b/index.js
@@ -135,7 +135,8 @@ export default function stringifyObject(input, options, pad) {
 					if ('prototype' in f) return null;
 					const s = f.toString();
 					if (s.charAt(0) == '(') return null;
-					if (/^[_$a-zA-Z0-9]+\s*=>/.test(s)) return null;
+                    const re = /^[_$a-zA-Z0-9]+(\s+|\/\/.*\n|\/\*.*?\*\/)*=>/
+					if (re.test(s)) return null;
 					return s;
 				}
 				const method = isMethodFunction(element, input);

--- a/index.js
+++ b/index.js
@@ -176,6 +176,7 @@ export function isMethodFunction(f) {
 	const variable = /^[_$a-zA-Z0-9]+/;
 	const arrow = /^=>/;
 	const func = /^function(\s|\(|\/|\*)/;
+	const clas = /^class(\s|\{|\/|\*)/;
 
 	if (fn == 'AsyncFunction' || fn == 'AsyncGeneratorFunction') {
 		s = s.slice(5).replace(comment, '');
@@ -186,6 +187,10 @@ export function isMethodFunction(f) {
 	}
 	if (func.test(s) && f.name !== 'function') {
 		// exclude function as method name {function() {}}
+		return null;
+	}
+	if (clas.test(s) && f.name !== 'class') {
+		// exclude class as method name {class() {}}
 		return null;
 	}
 	if (variable.test(s)) {

--- a/index.js
+++ b/index.js
@@ -129,6 +129,18 @@ export default function stringifyObject(input, options, pad) {
 					value = options.transform(input, element, value);
 				}
 
+				function isMethodFunction(k, o) {
+					const f = o[k];
+					if (typeof f !== 'function') return null
+					if ('prototype' in f) return null;
+					const s = f.toString();
+					if (s.charAt(0) == '(') return null;
+					if (/^[_$a-zA-Z0-9]+\s*=>/.test(s)) return null;
+					return s;
+				}
+				const method = isMethodFunction(element, input);
+				if (method) return tokens.indent + method + eol;
+
 				return tokens.indent + String(key) + ': ' + value + eol;
 			}).join('') + tokens.pad + '}';
 

--- a/test/fixtures/object.js
+++ b/test/fixtures/object.js
@@ -24,7 +24,7 @@
   Infinity: Infinity,
   newlines: "foo\nbar\r\nbaz",
   circular: "[Circular]",
-  Symbol(): Symbol(),
-  Symbol(foo): Symbol(foo),
-  Symbol(foo): Symbol(foo)
+  [Symbol()]: Symbol(),
+  [Symbol("foo")]: Symbol("foo"),
+  [Symbol.for("foo")]: Symbol.for("foo")
 }

--- a/test/index.js
+++ b/test/index.js
@@ -199,5 +199,14 @@ test('don\'t stringify non-enumerable symbols', t => {
 	const symbol = Symbol('for non-enumerable key');
 	Object.defineProperty(object, symbol, {enumerable: false});
 
-	t.is(stringifyObject(object), '{\n\tSymbol(for enumerable key): undefined\n}');
+	t.is(stringifyObject(object), '{\n\t[Symbol(\'for enumerable key\')]: undefined\n}');
+});
+test('handle symbols', t => {
+	const object = {
+		[Symbol('unique')]: Symbol('unique'),
+		[Symbol.for('registry')]: [Symbol.for('registry'), 2],
+		[Symbol.iterator]: {k: Symbol.iterator},
+		[Symbol()]: 'undef'
+	};
+	t.is(stringifyObject(object), '{\n\t[Symbol(\'unique\')]: Symbol(\'unique\'),\n\t[Symbol.for(\'registry\')]: [\n\t\tSymbol.for(\'registry\'),\n\t\t2\n\t],\n\t[Symbol.iterator]: {\n\t\tk: Symbol.iterator\n\t},\n\t[Symbol()]: \'undef\'\n}');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -212,43 +212,46 @@ test('handle symbols', t => {
 });
 
 test('method function test', t => {
-    const arrow = [
-        async_v => 0, async => 0, async x => 0, async /* foo => */ => 0,
-        /* c1 */ async /* => () */ /*c2*/ x /* c3 */ /* cm4 */ => /* cm5 */ 3,
-        async_v/**/ => 0, async() => 0, async(x) => 0, async (/* cm */ x) => 0,
-        async/* foo => */=> 0, async/* foo x*/x=> 0, async/* foo => */x=> 0,
-        async /* => () */ /*yoy*/ /* comment */ /* cm2 */ => /* cm3 */ 3,
-        async $=>0
-    ];
-    arrow.forEach(f => t.is(isMethodFunction(f), null));
-    const obj = [
-        {m() {}}, {m_m() {}}, {_1() {}}, {_1_(){}}, {' '() {}}, {' , '(){}},
-        {m /* c */ () {}}, {m_m /**/ () {}}, {__1 /*c1*/ /*c2*/() {}},
-        {_1__ // comment to line end
-         (){}}, {' ' // c2eol
-                 /* c2 */ () /*c3*/ {}}, {/*c4*/' , '(){}},
-        {1() {}}, {'1.0'() {}}, {1_1() {}}, {'1_'(){}},
-        {' () => 0 '() {}}, {'x=>{}'(){}}, {async() {}},
-        {$$/**/() {}}, {'m()'() {}}, {'"q"'() {}}, {'\'q'(){}},
-        {'/* c */ '() {}}, {'// '(){}}, {''(){}},
-        {'\n // \\'() {}}, {'{}'() {}}, {'(\')'() {}}, {'\''(){}}
-    ];
-    obj.forEach(o => {
-        const m = Object.keys(o)[0];
-        t.is(typeof isMethodFunction(o[m]), 'string');
-    });
-    t.not(isMethodFunction(({async() {}}).async), null);
-    t.is(isMethodFunction(async()=>{}), null);
+	const arrow = [
+		async_v => 0, async => 0, async x => 0, async /* foo => */ => 0,
+		/* c1 */ async /* => () */ /*c2*/ x /* c3 */ /* cm4 */ => /* cm5 */ 3,
+		async_v/**/ => 0, async() => 0, async(x) => 0, async (/* cm */ x) => 0,
+		async/* foo => */=> 0, async/* foo x*/x=> 0, async/* foo => */x=> 0,
+		async /* => () */ /*yoy*/ /* comment */ /* cm2 */ => /* cm3 */ 3,
+		async $=>0
+	];
+	arrow.forEach(f => t.is(isMethodFunction(f), null));
+	const obj = [
+		{m() {}}, {m_m() {}}, {_1() {}}, {_1_(){}}, {' '() {}}, {' , '(){}},
+		{m /* c */ () {}}, {m_m /**/ () {}}, {__1 /*c1*/ /*c2*/() {}},
+		{_1__ // comment to line end
+		 (){}}, {' ' // c2eol
+				 /* c2 */ () /*c3*/ {}}, {/*c4*/' , '(){}},
+		{1() {}}, {'1.0'() {}}, {1_1() {}}, {'1_'(){}},
+		{' () => 0 '() {}}, {'x=>{}'(){}}, {async() {}},
+		{$$/**/() {}}, {'m()'() {}}, {'"q"'() {}}, {'\'q'(){}},
+		{'/* c */ '() {}}, {'// '(){}}, {''(){}},
+		{'\n // \\'() {}}, {'{}'() {}}, {'(\')'() {}}, {'\''(){}}
+	];
+	obj.map(o => Object.values(o)).flat().forEach(m => {
+		t.not(isMethodFunction(m), null);
+	});
+	t.not(isMethodFunction(({async() {}}).async), null);
+	t.is(isMethodFunction(async()=>{}), null);
+
+	t.not(isMethodFunction(({function() {}})['function']), null);
+	t.is(isMethodFunction(function() {}), null);
 });
 
 test('method function stringify', t => {
-    const obj = {
-        method() {},
-        arrow: () => {},
-        async ma() {},
-        asynca: async() => {},
-        asynca2: async => {},
-        async() {}
-    };
-    t.is(stringifyObject(obj), '{\n\tmethod() {},\n\tarrow: () => {},\n\tasync ma() {},\n\tasynca: async() => {},\n\tasynca2: async => {},\n\tasync() {}\n}');
+	const obj = {
+		method() {},
+		arrow: () => {},
+		async ma() {},
+		asynca: async() => {},
+		asynca2: async => {},
+		async() {},
+		function() {}
+	};
+	t.is(stringifyObject(obj), '{\n\tmethod() {},\n\tarrow: () => {},\n\tasync ma() {},\n\tasynca: async() => {},\n\tasynca2: async => {},\n\tasync() {},\n\tfunction() {}\n}');
 });

--- a/test/index.js
+++ b/test/index.js
@@ -251,7 +251,9 @@ test('method function stringify', t => {
 		asynca: async() => {},
 		asynca2: async => {},
 		async() {},
+		class() {},
+		klass: class {},
 		function() {}
 	};
-	t.is(stringifyObject(obj), '{\n\tmethod() {},\n\tarrow: () => {},\n\tasync ma() {},\n\tasynca: async() => {},\n\tasynca2: async => {},\n\tasync() {},\n\tfunction() {}\n}');
+	t.is(stringifyObject(obj), '{\n\tmethod() {},\n\tarrow: () => {},\n\tasync ma() {},\n\tasynca: async() => {},\n\tasynca2: async => {},\n\tasync() {},\n\tclass() {},\n\tklass: class {},\n\tfunction() {}\n}');
 });


### PR DESCRIPTION
I saw you merge some PRs.
Maybe you will interested in this PR, too?

These commits will stringify following object correctly:

```js
var obj = {
    method() {},
    arrow: () => {},
    async ma() {},
    asynca: async() => {},
    asynca2: async => {},
    async() {},
    class() {},
    klass: class {},
    function() {}
};
```

It also handle comment between function name and function body.
(See test cases)

I saw you close #65 , but I want this feature,
so I add it in my own fork.

I add many test cases for this feature.
If you would like to merge these commits,
I can rebase them on the current version.